### PR TITLE
print filename if crop fails

### DIFF
--- a/autocrop/autocrop.py
+++ b/autocrop/autocrop.py
@@ -257,17 +257,22 @@ def main(
 
         input_img = open_file(input_filename)
 
+        image = None
         # Attempt the crop
-        image = crop(
-            input_img,
-            fheight,
-            fwidth,
-            facePercent,
-            padUp,
-            padDown,
-            padLeft,
-            padRight,
-        )
+        try:
+            image = crop(
+                input_img,
+                fheight,
+                fwidth,
+                facePercent,
+                padUp,
+                padDown,
+                padLeft,
+                padRight,
+            )
+        except:
+            print("Error:            {}".format(input_filename))
+            continue
 
         # Did the crop produce a valid image
         if isinstance(image, type(None)):

--- a/autocrop/autocrop.py
+++ b/autocrop/autocrop.py
@@ -187,7 +187,7 @@ def crop(
 
 def open_file(input_filename):
     """Given a filename, returns a numpy array"""
-    extension = os.path.splitext(input_filename)[1]
+    extension = os.path.splitext(input_filename)[1].lower()
 
     if extension in CV2_FILETYPES:
         # Try with cv2


### PR DESCRIPTION
sometimes the `crop()` function (reproducibly) fails to crop an image. I have not been able to determine why. but this code fails with an `AttributeError`:

```
    # Scale the image
    height, width = image.shape[:2]
```

fixing this failure might warrant its own issue. ~however, this PR does not attempt to do so~

instead, this PR catches any exception raised when calling `crop()` and:

- prints an error message for the file
- skips the file
- continues processing

the result will be an input directory with files autocrop was unable to process