### PR TITLE
Remove duplicate lines in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,6 @@ The following file types are supported:
 - LabEye IM files (`.im`)
 - macOS ICNS files (`.icns`)
 - Microsoft Paint bitmap files (`.msp`)
-- MSP files (`.msp`)
-- MSP files (`.msp`)
 - PCX files (`.pcx`)
 - Portable Network Graphics (`.png`)
 - Portable Pixmap files (`.pbm`, `.pgm`, `.ppm`)


### PR DESCRIPTION
MSP files are only used in Microsoft Paint, and there were 3 consecutive lines stating support of this filetype with 2 of them being exactly identical. I've changed this so that only the most descriptive line remains.