### PR TITLE
Update pytest

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,5 @@
 future==0.10.0
-pytest==4.0.2
+pytest==5.2.0
 flake8==3.5.0
 mock==2.0.0
 pytest-cov==2.6.1


### PR DESCRIPTION
An `attrs` package update causes older versions of `pytest` to error out. Upgrading version.

See: https://stackoverflow.com/questions/58189683/typeerror-attrib-got-an-unexpected-keyword-argument-convert