### PR TITLE
Pinning attrs to stable version

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,4 +4,4 @@ flake8==3.5.0
 mock==2.0.0
 pytest-cov==2.6.1
 codecov==2.0.15
-attrs=19.1.0
+attrs==19.1.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,3 +4,4 @@ flake8==3.5.0
 mock==2.0.0
 pytest-cov==2.6.1
 codecov==2.0.15
+attrs=19.1.0


### PR DESCRIPTION
Python 3-only version can then update to pytest-latest.