### PR TITLE
Add support for Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,8 @@ python:
   - "2.7"
   - "3.5"
   - "3.6"
-# Enable 3.7 without globally enabling sudo and dist: xenial for other build jobs
-matrix:
-  include:
-  - python: 3.7
-    dist: xenial
-    sudo: true
+  - "3.7"
+  - "3.8"
 fail_fast: true
 
 before_install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,10 +11,12 @@ environment:
     - PYTHON: "C:\\Python35"
     - PYTHON: "C:\\Python36"
     - PYTHON: "C:\\Python37"
+    - PYTHON: "C:\\Python38"
     - PYTHON: "C:\\Python27-x64"
     - PYTHON: "C:\\Python35-x64"
     - PYTHON: "C:\\Python36-x64"
     - PYTHON: "C:\\Python37-x64"
+    - PYTHON: "C:\\Python38-x64"
 
 install:
   # We need wheel installed to build wheels

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,6 +1,6 @@
 future==0.10.0
 pytest==4.0.2
-flake8==3.5.0
+flake8==3.7.9
 mock==2.0.0
 pytest-cov==2.6.1
 codecov==2.0.16

--- a/setup.py
+++ b/setup.py
@@ -90,14 +90,12 @@ setup(
     install_requires=REQUIRED,
     include_package_data=True,
     license="BSD 2-Clause",
-    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
+    python_requires=">=3.4",
     classifiers=[
         # Trove classifiers
         # Full list: https://pypi.python.org/pypi?%3Aaction=list_classifiers
         "License :: OSI Approved :: BSD License",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",

--- a/setup.py
+++ b/setup.py
@@ -90,15 +90,19 @@ setup(
     install_requires=REQUIRED,
     include_package_data=True,
     license="BSD 2-Clause",
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
     classifiers=[
         # Trove classifiers
         # Full list: https://pypi.python.org/pypi?%3Aaction=list_classifiers
         "License :: OSI Approved :: BSD License",
         "Programming Language :: Python",
+        "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
     ],
     # $ setup.py publish support.
     cmdclass={"upload": UploadCommand},


### PR DESCRIPTION
No longer need the workaround for 3.7+ on Travis, as Xenial is default and `sudo`  no longer has any effect.