### PR TITLE
Make CLI module only use PIL to save the cropped images

### DIFF
--- a/autocrop/__version__.py
+++ b/autocrop/__version__.py
@@ -1,4 +1,4 @@
 __title__ = "autocrop"
 __description__ = "Automatically crops faces from batches of pictures"
 __author__ = "François Leblanc"
-__version__ = "1.0.1"
+__version__ = "1.0.2"

--- a/autocrop/cli.py
+++ b/autocrop/cli.py
@@ -26,9 +26,7 @@ def output(input_filename, output_filename, image):
         # Move the file to the output directory
         shutil.move(input_filename, output_filename)
     # Encode the image as an in-memory PNG
-    img_png = cv2.imencode(".png", image)[1].tostring()
-    # Read the PNG data
-    img_new = Image.open(io.BytesIO(img_png))
+    img_new = Image.fromarray(image)
     # Write the new image (converting the format to match the output
     # filename if necessary)
     img_new.save(output_filename)

--- a/autocrop/cli.py
+++ b/autocrop/cli.py
@@ -1,6 +1,4 @@
 import argparse
-import cv2
-import io
 import os
 import shutil
 import sys


### PR DESCRIPTION
Fixes #100 blue-tint images saved.

OpenCV uses the BGR encoding for images while the rest of the world uses RBG. The `Cropper` class now outputs RBG-encoded, so we un-transform the image in the CLI module. It now uses PIL directly to save the image.