### PR TITLE
Update opencv-python to version 4.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 numpy>=1.10
-opencv-python>=4, <5
+opencv-python>=3, <5
 Pillow>5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 numpy>=1.10
-opencv-python>=3, <4
+opencv-python>=4, <5
 Pillow>5


### PR DESCRIPTION
Resolve #106. People are currently unable to use `autocrop` and recent versions of `opencv-python` in the same project. This should resolve that.