### PR TITLE
Drop support for Python 3.5 because it's EOL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 
 python:
-  - "3.5"
   - "3.6"
   - "3.7"
   - "3.8"

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Autocrop can be used [from the command line](#from-the-command-line) or directly
 	- Images where a face can't be detected will be left in `crop`.
 * Same as above, but output the images with undetected faces to the `reject` folder:
 	- `autocrop -i pics -o crop -r reject -w 400 -H 400`.
-	
+
 If no output folder is added, asks for confirmation and destructively crops images in-place.
 
 ### From Python
@@ -119,7 +119,7 @@ Best practice for your projects is of course to [use virtual environments](http:
 
 Autocrop is currently being tested on:
 
-* Python 3.5+
+* Python 3.6+
 * OS:
     - Linux
     - macOS

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,15 +1,11 @@
 environment:
-
   matrix:
-
     # For Python versions available on AppVeyor, see
     # http://www.appveyor.com/docs/installed-software#python
 
-    - PYTHON: "C:\\Python35"
     - PYTHON: "C:\\Python36"
     - PYTHON: "C:\\Python37"
     - PYTHON: "C:\\Python38"
-    - PYTHON: "C:\\Python35-x64"
     - PYTHON: "C:\\Python36-x64"
     - PYTHON: "C:\\Python37-x64"
     - PYTHON: "C:\\Python38-x64"
@@ -34,4 +30,3 @@ test_script:
   # to put the Python version you want to use on PATH.
   # - "build.cmd %PYTHON%\\python.exe setup.py test"
   - "%PYTHON%\\python.exe -m pytest --cov autocrop -v --cov-report term-missing"
-

--- a/setup.py
+++ b/setup.py
@@ -88,13 +88,12 @@ setup(
     install_requires=REQUIRED,
     include_package_data=True,
     license="BSD 2-Clause",
-    python_requires=">=3.5",
+    python_requires=">=3.6",
     classifiers=[
         # Trove classifiers
         # Full list: https://pypi.python.org/pypi?%3Aaction=list_classifiers
         "License :: OSI Approved :: BSD License",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # content of: tox.ini , put in same dir as setup.py
 [tox]
-envlist = py35,py36,py37,py38
+envlist = py36,py37,py38
 requires = tox-conda
 
 [testenv]


### PR DESCRIPTION
At the end of September 2020, [Python 3.5 reached EOL](https://www.python.org/downloads/release/python-3510/). The `opencv-python` project stopped producing wheels for it. Using `opency-python` with Python 3.5 requires building it from source. This is slow and error prone. By removing support for Python 3.5, we avoid building from source and overall CI times go way down.