### PR TITLE
Allow project to build with opencv-python v4.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ EMAIL = "leblancfg@gmail.com"
 AUTHOR = "François Leblanc"
 
 # What packages are required for this module to be executed?
-REQUIRED = ["numpy>=1.10", "opencv-python>=3, <4", "Pillow>5"]
+REQUIRED = ["numpy>=1.10", "opencv-python>=3, <5", "Pillow>5"]
 
 # The rest you shouldn't have to touch too much :)
 # ------------------------------------------------


### PR DESCRIPTION
Resolves #109.

The `REQUIRED` rules in `setup.py` only allowed `opencv-python` v3. Now they'll allow v3 and v4.

Now `poetry` users with v4 can put this line in their `pyproject.toml` files.

```toml
[tool.poetry.dependencies]
autocrop = { git = "https://github.com/leblancfg/autocrop.git" }
```