### PR TITLE
Deprecate python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 
 python:
-  - "3.5"
   - "3.6"
   - "3.7"
   - "3.8"

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Best practice for your projects is of course to [use virtual environments](http:
 
 Autocrop is currently being tested on:
 
-* Python 3.5+
+* Python 3.6+
 * OS:
     - Linux
     - macOS

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,11 +5,9 @@ environment:
     # For Python versions available on AppVeyor, see
     # http://www.appveyor.com/docs/installed-software#python
 
-    - PYTHON: "C:\\Python35"
     - PYTHON: "C:\\Python36"
     - PYTHON: "C:\\Python37"
     - PYTHON: "C:\\Python38"
-    - PYTHON: "C:\\Python35-x64"
     - PYTHON: "C:\\Python36-x64"
     - PYTHON: "C:\\Python37-x64"
     - PYTHON: "C:\\Python38-x64"

--- a/setup.py
+++ b/setup.py
@@ -88,13 +88,12 @@ setup(
     install_requires=REQUIRED,
     include_package_data=True,
     license="BSD 2-Clause",
-    python_requires=">=3.5",
+    python_requires=">=3.6",
     classifiers=[
         # Trove classifiers
         # Full list: https://pypi.python.org/pypi?%3Aaction=list_classifiers
         "License :: OSI Approved :: BSD License",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,11 @@
 # content of: tox.ini , put in same dir as setup.py
 [tox]
-envlist = py35,py36,py37,py38
-requires = tox-conda
+envlist = py36,py37,py38
+# requires = tox-conda
 
 [testenv]
 # install pytest in the virtualenv where commands will be executed
 deps =
-    -rrequirements.txt
     -rrequirements-dev.txt
 commands =
     # NOTE: you can run any command line tool here - not just tests


### PR DESCRIPTION
This PR deprecates Python 3.5, which is now past its maintenance lifetime.