### PR TITLE
Added the flag --no-resize for just cropping the image and saving it.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,6 @@ notes.md
 
 # Jupyter Notebooks
 .ipynb_checkpoints
+
+# VsCode Junk
+.vscode/

--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ Further examples and use cases are found in the [accompanying Jupyter Notebook](
 	  -e, --extension
 	  		Enter the image extension which to save at output.
 	  		Default: Your current image extension
+	  --no-resize
+	  		Do not resize the output image.
+			It will just crop the image and save it.
 	  -v, --version
 	  		Show program's version number and exit
 

--- a/autocrop/autocrop.py
+++ b/autocrop/autocrop.py
@@ -128,11 +128,13 @@ class Cropper:
         face_percent=50,
         padding=None,
         fix_gamma=True,
+        no_resize=False,
     ):
         self.height = check_positive_scalar(height)
         self.width = check_positive_scalar(width)
         self.aspect_ratio = width / height
         self.gamma = fix_gamma
+        self.no_resize = no_resize
 
         # Face percent
         if face_percent > 100 or face_percent < 1:
@@ -207,10 +209,15 @@ class Cropper:
         # ====== Actual cropping ======
         image = image[pos[0] : pos[1], pos[2] : pos[3]]
 
-        # Resize
-        image = cv2.resize(
-            image, (self.width, self.height), interpolation=cv2.INTER_AREA
-        )
+        """
+        Check if the no resize flag is given or not, if given,
+        it will not resize the image just crop it
+        """
+        if self.no_resize is not True:
+            # Resize
+            image = cv2.resize(
+                image, (self.width, self.height), interpolation=cv2.INTER_AREA
+            )
 
         # Underexposition
         if self.gamma:

--- a/autocrop/cli.py
+++ b/autocrop/cli.py
@@ -123,7 +123,7 @@ def main(
     # Stop and print status
 
     print(
-        f"{input_count} : Input files, {output_count} : Faces Cropped, {reject_count}"
+        f"{input_count} : Input files, {output_count} : Faces Cropped, {reject_count} : Rejected"
     )
 
 

--- a/autocrop/cli.py
+++ b/autocrop/cli.py
@@ -224,8 +224,9 @@ def parse_args(args):
         "extension": "Enter the image extension which to save at output",
         "width": "Width of cropped files in px. Default=500",
         "height": "Height of cropped files in px. Default=500",
-        "y": "Bypass any confirmation prompts",
+        "no-confirm": "Bypass any confirmation prompts",
         "facePercent": "Percentage of face to image height",
+        "no-resizing": "Do not resize the output image",
     }
 
     parser = argparse.ArgumentParser(description=help_d["desc"])
@@ -252,12 +253,15 @@ def parse_args(args):
         action="version",
         version="%(prog)s version {}".format(__version__),
     )
-    parser.add_argument("--no-confirm", action="store_true", help=help_d["y"])
+    parser.add_argument("--no-confirm", action="store_true", help=help_d["no-confirm"])
     parser.add_argument(
         "--facePercent", type=size, default=50, help=help_d["facePercent"]
     )
     parser.add_argument(
         "-e", "--extension", type=chk_extension, default=None, help=help_d["extension"]
+    )
+    parser.add_argument(
+        "--no-resizing", action="store_true", help=help_d["no-resizing"]
     )
 
     return parser.parse_args()

--- a/autocrop/cli.py
+++ b/autocrop/cli.py
@@ -38,7 +38,7 @@ def reject(input_filename, reject_filename):
 
 
 def main(
-    input_d, output_d, reject_d, extension=None, fheight=500, fwidth=500, facePercent=50
+    input_d, output_d, reject_d, extension=None, fheight=500, fwidth=500, facePercent=50, no_resize=False,
 ):
     """Crops folder of images to the desired height and width if a
     face is found.
@@ -92,7 +92,16 @@ def main(
     assert input_count > 0
 
     # Main loop
-    cropper = Cropper(width=fwidth, height=fheight, face_percent=facePercent)
+
+    """
+    Check if the no resize flag is provided or not.
+    """
+
+    if no_resize is True:
+        cropper = Cropper(width=fwidth, height=fheight, face_percent=facePercent, no_resize=True)
+    else:
+        cropper = Cropper(width=fwidth, height=fheight, face_percent=facePercent)
+
     for input_filename in input_files:
         basename = os.path.basename(input_filename)
         if extension:
@@ -226,7 +235,7 @@ def parse_args(args):
         "height": "Height of cropped files in px. Default=500",
         "no-confirm": "Bypass any confirmation prompts",
         "facePercent": "Percentage of face to image height",
-        "no-resizing": "Do not resize the output image",
+        "no_resize": "Do not resize the output image",
     }
 
     parser = argparse.ArgumentParser(description=help_d["desc"])
@@ -261,7 +270,7 @@ def parse_args(args):
         "-e", "--extension", type=chk_extension, default=None, help=help_d["extension"]
     )
     parser.add_argument(
-        "--no-resizing", action="store_true", help=help_d["no-resizing"]
+        "--no-resize", action="store_true", help=help_d["no_resize"]
     )
 
     return parser.parse_args()
@@ -290,4 +299,5 @@ def command_line_interface():
         args.height,
         args.width,
         args.facePercent,
+        args.no_resize,
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -67,7 +67,7 @@ def test_cli_no_args_means_cwd(mock_main):
     sys.argv = ["", "--no-confirm"]
     command_line_interface()
     args, _ = mock_main.call_args
-    assert args == (".", None, None, None, 500, 500, 50)
+    assert args == (".", None, None, None, 500, 500, 50, True)
 
 
 @mock.patch("autocrop.cli.input_path", lambda p: p)


### PR DESCRIPTION
**Added the flag --no-resize for just cropping the image and saving it.**

This issue i also faced, and wanted to work on that, some times the small res images get all pixelated when its resized, and saw an opened issue #57 then i think that was the time.

**Things Done**
* Added the flag --no-resize 
* The print status was giving incomplete data (not printing number of rejected images)
* Updated the "README.md"

**How it works**

Basically when you pass *--no-resize* it will stored as True and in both API and the cli version script will check if the flagg is passed or not if yes then it will check the condition and call the *cropper* class based on that.

**Things to do**

I have tested it  in all means but, i don't know how to write the automatic testing script, but you can do it, or you can teach me how to do that, it will be very helpfull and thoughfull of you if you do that..