### PR TITLE
Autocrop version 1.2.0

### DIFF
--- a/autocrop/__version__.py
+++ b/autocrop/__version__.py
@@ -1,4 +1,4 @@
 __title__ = "autocrop"
 __description__ = "Automatically crops faces from batches of pictures"
 __author__ = "François Leblanc"
-__version__ = "1.1.1"
+__version__ = "1.2.0"

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.2.0 - 2021-11-26
+### Changes
+
+- Modify the `opencv-python` dependency over to `opencv-python-headless`, which doesn't have all the GUI baggage. Easier to download and package.
+
+### Documentation
+
+- Created the `examples` directory and moved the example notebook to it.
+
 ## 1.1.1 - 17-02-2021
 ### Deprecations
 


### PR DESCRIPTION
Recent changes have been big enough to bump the version of the package to 1.2.0, especially using the headless opencv. This will let users specify in their pip requirements that they can start using it.

Depends on #144 