### PR TITLE
Update 3.11 aplha to PRC4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         experimental: [false]
         include:
           - os: ubuntu-latest
-            python: "3.11.0-alpha.2"
+            python: "3.11.0-alpha.4"
             experimental: true
 
     steps:


### PR DESCRIPTION
Updates the pre-release candidate for Py3.11 from 2 to 4