### PR TITLE
Add wheel and twine to dev requirements

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,4 +6,6 @@ codecov
 attrs
 tox
 portray
+wheel
+twine
 -r requirements.txt


### PR DESCRIPTION
Thbese build dependencies are lightweight, and needed to build the release packages.