### PR TITLE
Add no-resize flag to the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,33 +40,32 @@ Further examples and use cases are found in the [accompanying Jupyter Notebook](
 
 ## From the command line
 
-	usage: [-h] [-o OUTPUT] [-i INPUT] [-w WIDTH] [-H HEIGHT] [-e EXTENSION] [-v]
+    usage: autocrop [-h] [-v] [--no-confirm] [-n] [-i INPUT] [-o OUTPUT] [-r REJECT] [-w WIDTH] [-H HEIGHT] [--facePercent FACEPERCENT]
+                    [-e EXTENSION]
 
-	Automatically crops faces from batches of pictures
+    Automatically crops faces from batches of pictures
 
-	optional arguments:
-	  -h, --help
-	  		Show this help message and exit
-	  -o, --output, -p, --path
-			Folder where cropped images will be placed.
-			Default: current working directory
-	  -r, --reject
-			Folder where images without detected faces will be placed.
-			Default: same as output directory
-	  -i, --input
-			Folder where images to crop are located.
-			Default: current working directory
-	  -w, --width
-			Width of cropped files in px. Default=500
-	  -H, --height
-			Height of cropped files in px. Default=500
-	  --facePercent
-	  		Zoom factor. Percentage of face height to image height.
-	  -e, --extension
-	  		Enter the image extension which to save at output.
-	  		Default: Your current image extension
-	  -v, --version
-	  		Show program's version number and exit
+    options:
+      -h, --help            Show this help message and exit
+      -v, --version         Show program's version number and exit
+      --no-confirm          Bypass any confirmation prompts
+      -n, --no-resize       Do not resize images to the specified width and height, but instead use the original image's pixels.
+      -i, --input INPUT
+                            Folder where images to crop are located. Default: current working directory
+      -o, -p, --output, --path OUTPUT
+                            Folder where cropped images will be moved to. Default: current working directory, meaning images are cropped in
+                            place.
+      -r, --reject REJECT
+                            Folder where images that could not be cropped will be moved to. Default: current working directory, meaning images
+                            that are not cropped will be left in place.
+      -w, --width WIDTH
+                            Width of cropped files in px. Default=500
+      -H, --height HEIGHT
+                            Height of cropped files in px. Default=500
+      --facePercent FACEPERCENT
+                            Percentage of face to image height
+      -e, --extension EXTENSION
+                            Enter the image extension which to save at output
 
 ### Examples
 
@@ -77,6 +76,8 @@ Further examples and use cases are found in the [accompanying Jupyter Notebook](
 	- `autocrop -i pics -o crop -r reject -w 400 -H 400`.
 * Same as above but the image extension will be `png`:
 	- `autocrop -i pics -o crop -w 400 -H 400 -e png`
+* Crop every image in the `pics` folder and output to the `crop` directory, but keep the original pixels from the images:
+    - `autocrop -i pics -o crop --no-resize`
 	
 If no output folder is added, asks for confirmation and destructively crops images in-place.
 

--- a/autocrop/autocrop.py
+++ b/autocrop/autocrop.py
@@ -182,7 +182,7 @@ class Cropper:
             img_height, img_width = image.shape[:2]
         except AttributeError:
             raise ImageReadError
-        minface = int(np.sqrt(img_height ** 2 + img_width ** 2) / MINFACE)
+        minface = int(np.sqrt(img_height**2 + img_width**2) / MINFACE)
 
         # Create the haar cascade
         face_cascade = cv2.CascadeClassifier(self.casc_path)

--- a/autocrop/cli.py
+++ b/autocrop/cli.py
@@ -2,6 +2,7 @@ import argparse
 import os
 import shutil
 import sys
+from typing import Optional
 
 from PIL import Image
 
@@ -40,8 +41,15 @@ def reject(input_filename, reject_filename):
 
 
 def main(
-    input_d, output_d, reject_d, extension=None, fheight=500, fwidth=500, facePercent=50
-):
+    input_d: str,
+    output_d: str,
+    reject_d: str,
+    extension: Optional[str] = None,
+    fheight: int = 500,
+    fwidth: int = 500,
+    facePercent: int = 50,
+    resize: bool = True,
+) -> None:
     """
     Crops folder of images to the desired height and width if a
     face is found.
@@ -66,15 +74,13 @@ def main(
         * Percentage of face from height.
     - `extension` : `str`
         * Image extension to save at output.
+    - `resize`: `bool`, default=`True`
+        * If `False`, don't resize the image, but use the original size.
 
     Side Effects:
     -------------
 
     - Creates image files in output directory.
-
-    Type Signature:
-    ---------------
-    `str, str, (int), (int) -> None`
     """
     reject_count = 0
     output_count = 0
@@ -95,7 +101,7 @@ def main(
     assert input_count > 0
 
     # Main loop
-    cropper = Cropper(width=fwidth, height=fheight, face_percent=facePercent)
+    cropper = Cropper(width=fwidth, height=fheight, face_percent=facePercent, resize=resize)
     for input_filename in input_files:
         basename = os.path.basename(input_filename)
         if extension:
@@ -230,6 +236,7 @@ def parse_args(args):
         "height": "Height of cropped files in px. Default=500",
         "y": "Bypass any confirmation prompts",
         "facePercent": "Percentage of face to image height",
+        "no_resize": "Do not resize images to the specified width and height, but instead use the original image's pixels.",
     }
 
     parser = argparse.ArgumentParser(description=help_d["desc"])
@@ -263,6 +270,13 @@ def parse_args(args):
     parser.add_argument(
         "-e", "--extension", type=chk_extension, default=None, help=help_d["extension"]
     )
+    parser.add_argument(
+        # False by default
+        "-n",
+        "--no-resize",
+        action="store_true",
+        help=help_d["no_resize"],
+    )
 
     return parser.parse_args()
 
@@ -282,6 +296,7 @@ def command_line_interface():
         args.output = None
     print("Processing images in folder:", args.input)
 
+    resize = not args.no_resize
     main(
         args.input,
         args.output,
@@ -290,4 +305,5 @@ def command_line_interface():
         args.height,
         args.width,
         args.facePercent,
+        resize,
     )

--- a/autocrop/cli.py
+++ b/autocrop/cli.py
@@ -101,7 +101,9 @@ def main(
     assert input_count > 0
 
     # Main loop
-    cropper = Cropper(width=fwidth, height=fheight, face_percent=facePercent, resize=resize)
+    cropper = Cropper(
+        width=fwidth, height=fheight, face_percent=facePercent, resize=resize
+    )
     for input_filename in input_files:
         basename = os.path.basename(input_filename)
         if extension:
@@ -236,10 +238,24 @@ def parse_args(args):
         "height": "Height of cropped files in px. Default=500",
         "y": "Bypass any confirmation prompts",
         "facePercent": "Percentage of face to image height",
-        "no_resize": "Do not resize images to the specified width and height, but instead use the original image's pixels.",
+        "no_resize": """Do not resize images to the specified width and height,
+                      but instead use the original image's pixels.""",
     }
 
     parser = argparse.ArgumentParser(description=help_d["desc"])
+    parser.add_argument(
+        "-v",
+        "--version",
+        action="version",
+        version="%(prog)s version {}".format(__version__),
+    )
+    parser.add_argument("--no-confirm", action="store_true", help=help_d["y"])
+    parser.add_argument(
+        "-n",
+        "--no-resize",
+        action="store_true",
+        help=help_d["no_resize"],
+    )
     parser.add_argument(
         "-i", "--input", default=".", type=input_path, help=help_d["input"]
     )
@@ -258,24 +274,10 @@ def parse_args(args):
     parser.add_argument("-w", "--width", type=size, default=500, help=help_d["width"])
     parser.add_argument("-H", "--height", type=size, default=500, help=help_d["height"])
     parser.add_argument(
-        "-v",
-        "--version",
-        action="version",
-        version="%(prog)s version {}".format(__version__),
-    )
-    parser.add_argument("--no-confirm", action="store_true", help=help_d["y"])
-    parser.add_argument(
         "--facePercent", type=size, default=50, help=help_d["facePercent"]
     )
     parser.add_argument(
         "-e", "--extension", type=chk_extension, default=None, help=help_d["extension"]
-    )
-    parser.add_argument(
-        # False by default
-        "-n",
-        "--no-resize",
-        action="store_true",
-        help=help_d["no_resize"],
     )
 
     return parser.parse_args()

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.3.1 - 2022-02-08
+### API Additions
+* The `Cropper` class now accepts a `resize` arg, to determine whether to resize the image after cropping it or not.
+* Similarly for the CLI, it can now be called with a `--no-resize` flag
+
+### Other changes
+* The order of CLI args when calling `autocrop --help` changed to place flags first
+* Start using type hints across the codebase
+
 ## 1.3.0 - 2022-01-25
 ### Changes
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,11 @@
 from _pytest.mark import Mark
 
 
-empty_mark = Mark('', [], {})
+empty_mark = Mark("", [], {})
 
 
 def by_slow_marker(item):
-    return item.get_closest_marker('slow', default=empty_mark)
+    return item.get_closest_marker("slow", default=empty_mark)
 
 
 def pytest_collection_modifyitems(items):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -273,3 +273,19 @@ def test_extension_parameter(integration):
     command_line_interface()
     output_files = os.listdir("tests/crop")
     assert all(f.endswith(".png") for f in output_files)
+
+
+@pytest.mark.slow
+def test_no_resize_flag(integration):
+    sys.argv = [
+        "",
+        "--no-confirm",
+        "-i",
+        "tests/test",
+        "-o",
+        "tests/crop",
+        "--no-resize",
+    ]
+    command_line_interface()
+    img = cv2.imread("tests/crop/obama.jpg")
+    assert img.shape == (434, 434, 3)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -67,7 +67,7 @@ def test_cli_no_args_means_cwd(mock_main):
     sys.argv = ["", "--no-confirm"]
     command_line_interface()
     args, _ = mock_main.call_args
-    assert args == (".", None, None, None, 500, 500, 50)
+    assert args == (".", None, None, None, 500, 500, 50, True)
 
 
 @mock.patch("autocrop.cli.input_path", lambda p: p)


### PR DESCRIPTION
Adds the option to not resize the cropped image, and simply save the original image pixels directly.

Closes #57 