### PR TITLE
Only open files with PIL to handle transparency

### DIFF
--- a/autocrop/autocrop.py
+++ b/autocrop/autocrop.py
@@ -10,13 +10,8 @@ from .constants import (
     MINFACE,
     GAMMA_THRES,
     GAMMA,
-    CV2_FILETYPES,
-    PILLOW_FILETYPES,
     CASCFILE,
 )
-
-COMBINED_FILETYPES = CV2_FILETYPES + PILLOW_FILETYPES
-INPUT_FILETYPES = COMBINED_FILETYPES + [s.upper() for s in COMBINED_FILETYPES]
 
 
 class ImageReadError(BaseException):

--- a/autocrop/autocrop.py
+++ b/autocrop/autocrop.py
@@ -84,16 +84,8 @@ def check_positive_scalar(num):
 
 def open_file(input_filename):
     """Given a filename, returns a numpy array"""
-    extension = os.path.splitext(input_filename)[1].lower()
-
-    if extension in CV2_FILETYPES:
-        # Try with cv2
-        return cv2.imread(input_filename)
-    if extension in PILLOW_FILETYPES:
-        # Try with PIL
-        with Image.open(input_filename) as img_orig:
-            return np.asarray(img_orig)
-    return None
+    with Image.open(input_filename) as img_orig:
+        return np.asarray(img_orig)
 
 
 class Cropper:

--- a/autocrop/cli.py
+++ b/autocrop/cli.py
@@ -10,12 +10,8 @@ from .__version__ import __version__
 from .autocrop import Cropper, ImageReadError
 from .constants import (
     QUESTION_OVERWRITE,
-    CV2_FILETYPES,
-    PILLOW_FILETYPES,
+    INPUT_FILETYPES,
 )
-
-COMBINED_FILETYPES = CV2_FILETYPES + PILLOW_FILETYPES
-INPUT_FILETYPES = COMBINED_FILETYPES + [s.upper() for s in COMBINED_FILETYPES]
 
 
 def output(input_filename, output_filename, image):
@@ -212,7 +208,7 @@ def chk_extension(extension):
     extension = str(extension).lower()
     if not extension.startswith("."):
         extension = f".{extension}"
-    if extension in COMBINED_FILETYPES:
+    if extension in INPUT_FILETYPES:
         return extension.lower().replace(".", "")
     else:
         raise argparse.ArgumentTypeError(error)

--- a/autocrop/constants.py
+++ b/autocrop/constants.py
@@ -5,38 +5,4 @@ GAMMA_THRES = 0.001
 GAMMA = 0.90
 FACE_RATIO = 6  # Face / padding ratio
 QUESTION_OVERWRITE = "Overwrite image files?"
-
-# File types supported by OpenCV
-CV2_FILETYPES = [
-    ".bmp",
-    ".dib",
-    ".jp2",
-    ".jpe",
-    ".jpeg",
-    ".jpg",
-    ".pbm",
-    ".pgm",
-    ".png",
-    ".ppm",
-    ".ras",
-    ".sr",
-    ".tif",
-    ".tiff",
-    ".webp",
-]
-
-# File types supported by Pillow
-PILLOW_FILETYPES = [
-    ".eps",
-    ".gif",
-    ".icns",
-    ".ico",
-    ".im",
-    ".msp",
-    ".pcx",
-    ".sgi",
-    ".spi",
-    ".xbm",
-]
-
 CASCFILE = "haarcascade_frontalface_default.xml"

--- a/autocrop/constants.py
+++ b/autocrop/constants.py
@@ -1,3 +1,5 @@
+from PIL import Image
+
 FIXEXP = True  # Flag to fix underexposition
 MINFACE = 8  # Minimum face size ratio; too low and we get false positives
 INCREMENT = 0.06
@@ -6,3 +8,6 @@ GAMMA = 0.90
 FACE_RATIO = 6  # Face / padding ratio
 QUESTION_OVERWRITE = "Overwrite image files?"
 CASCFILE = "haarcascade_frontalface_default.xml"
+
+PILLOW_FILETYPES = [k for k in Image.registered_extensions().keys()]
+INPUT_FILETYPES = PILLOW_FILETYPES + [s.upper() for s in PILLOW_FILETYPES]

--- a/tests/test_autocrop.py
+++ b/tests/test_autocrop.py
@@ -6,7 +6,7 @@ import pytest  # noqa: F401
 import cv2
 import numpy as np
 
-from autocrop.autocrop import gamma, Cropper, ImageReadError
+from autocrop.autocrop import gamma, Cropper
 
 
 @pytest.fixture()
@@ -49,12 +49,11 @@ def test_obama_has_a_face():
     assert len(c.crop(obama)) == 500
 
 
-def test_open_file_invalid_filetype_returns_None():
+def test_open_file_invalid_filetype_returns_error():
     c = Cropper()
-    with pytest.raises(ImageReadError) as e:
+    with pytest.raises(FileNotFoundError) as e:
         c.crop("asdf")
-    assert e.type == ImageReadError
-    assert "ImageReadError" in str(e)
+    assert "No such file" in str(e)
 
 
 @pytest.mark.parametrize(
@@ -107,7 +106,7 @@ def test_resize(resize, integration):
     if resize:
         assert img_array.shape == (500, 500, 3)
     else:
-        assert img_array.shape == (434, 434, 3)
+        assert img_array.shape == (430, 430, 3)
 
 
 @pytest.mark.parametrize("face_percent", [0, 101, "asdf"])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -288,4 +288,4 @@ def test_no_resize_flag(integration):
     ]
     command_line_interface()
     img = cv2.imread("tests/crop/obama.jpg")
-    assert img.shape == (434, 434, 3)
+    assert img.shape == (430, 430, 3)


### PR DESCRIPTION
Opens all files with the PIL library instead of selectively so with either CV2 or PIL. The former is slightly faster, but the latter handles more edge cases, and we'd rather have a tool that's more useful than one that is "specialized".

Closes #65 