### PR TITLE
Add `--skip-prompt` as a synonym for `--no-confirm`

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ Further examples and use cases are found in the [accompanying Jupyter Notebook](
     options:
       -h, --help            Show this help message and exit
       -v, --version         Show program's version number and exit
-      --no-confirm          Bypass any confirmation prompts
+      --no-confirm, --skip-prompt
+                            Bypass any confirmation prompts
       -n, --no-resize       Do not resize images to the specified width and height, but instead use the original image's pixels.
       -i, --input INPUT
                             Folder where images to crop are located. Default: current working directory

--- a/autocrop/cli.py
+++ b/autocrop/cli.py
@@ -247,7 +247,7 @@ def parse_args(args):
     )
     parser.add_argument(
         "--no-confirm",
-        "--skip-prompt"
+        "--skip-prompt",
         action="store_true", help=help_d["y"]
     )
     parser.add_argument(

--- a/autocrop/cli.py
+++ b/autocrop/cli.py
@@ -245,7 +245,11 @@ def parse_args(args):
         action="version",
         version="%(prog)s version {}".format(__version__),
     )
-    parser.add_argument("--no-confirm", action="store_true", help=help_d["y"])
+    parser.add_argument(
+        "--no-confirm",
+        "--skip-prompt"
+        action="store_true", help=help_d["y"]
+    )
     parser.add_argument(
         "-n",
         "--no-resize",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -192,9 +192,16 @@ def test_user_does_not_get_prompted_if_output_d_is_given(mock_confirm):
 
 @mock.patch("autocrop.cli.main", lambda *args: None)
 @mock.patch("autocrop.cli.confirmation")
-def test_user_does_not_get_prompted_if_no_confirm(mock_confirm):
+@pytest.mark.parametrize(
+    "flag",
+    [
+        ("--no-confirm"),
+        ("--skip-prompt"),
+    ],
+)
+def test_user_does_not_get_prompted_if_no_confirm(mock_confirm, flag):
     mock_confirm.return_value = False
-    sys.argv = ["", "-i", "tests/data", "--no-confirm"]
+    sys.argv = ["", "-i", "tests/data", flag]
     assert mock_confirm.call_count == 0
     command_line_interface()
     assert mock_confirm.call_count == 0


### PR DESCRIPTION
Sorry @juno-w, I tried fixing the syntax error but ended up closing your PR. Your commit is still signed to your name though! 💪🏻  Thanks for that.