### PR TITLE
Replace calls to `np.asarray` with `np.array`

### DIFF
--- a/autocrop/autocrop.py
+++ b/autocrop/autocrop.py
@@ -83,7 +83,7 @@ def check_positive_scalar(num):
 def open_file(input_filename):
     """Given a filename, returns a numpy array"""
     with Image.open(input_filename) as img_orig:
-        return np.asarray(img_orig)
+        return np.array(img_orig)
 
 
 class Cropper:
@@ -207,7 +207,7 @@ class Cropper:
         # Resize
         if self.resize:
             with Image.fromarray(image) as img:
-                image = np.asarray(img.resize((self.width, self.height)))
+                image = np.array(img.resize((self.width, self.height)))
 
         # Underexposition fix
         if self.gamma:


### PR DESCRIPTION
When using newer versions of `numpy`, we get the following error:

```
ValueError: assignment destination is read-only
```

This is because of two calls to `np.asarray`, that should be instead pointing to `np.array`, as the former is returned as read-only.