### PR TITLE
Keep crop positions inside image bounds

### DIFF
--- a/autocrop/autocrop.py
+++ b/autocrop/autocrop.py
@@ -327,4 +327,24 @@ class Cropper:
         v1 = y - ypad
         v2 = y + h + ypad
 
-        return [int(v1), int(v2), int(h1), int(h2)]
+        v1, v2, h1, h2 = int(v1), int(v2), int(h1), int(h2)
+
+        if h1 < 0:
+            h2 -= h1
+            h1 = 0
+        if h2 > imgw:
+            h1 -= h2 - imgw
+            h2 = imgw
+        if v1 < 0:
+            v2 -= v1
+            v1 = 0
+        if v2 > imgh:
+            v1 -= v2 - imgh
+            v2 = imgh
+
+        return [
+            max(0, v1),
+            min(imgh, v2),
+            max(0, h1),
+            min(imgw, h2),
+        ]

--- a/tests/test_autocrop.py
+++ b/tests/test_autocrop.py
@@ -75,6 +75,27 @@ def test_adjust_boundaries(values, expected_result):
     assert result == expected_result
 
 
+@pytest.mark.parametrize(
+    "values",
+    [
+        (663, 2495, 185, 867, 327, 354),
+        (612, 1020, 13, 280, 26, 33),
+        (612, 1020, 979, 282, 24, 34),
+        (612, 1020, 1003, 169, 16, 21),
+        (612, 1020, 993, 351, 26, 44),
+        (612, 1020, 996, 271, 21, 26),
+        (612, 1020, 9, 382, 30, 49),
+        (612, 1020, 0, 231, 14, 27),
+    ],
+)
+def test_crop_positions_stay_inside_image_bounds(values):
+    imgh, imgw, x, y, w, h = values
+    c = Cropper()
+    v1, v2, h1, h2 = c._crop_positions(imgh, imgw, x, y, w, h)
+    assert 0 <= v1 < v2 <= imgh
+    assert 0 <= h1 < h2 <= imgw
+
+
 @pytest.mark.slow
 @pytest.mark.parametrize(
     "height, width",


### PR DESCRIPTION
## Summary
- shift computed crop windows back inside image bounds while preserving crop size where possible
- clamp final crop coordinates as a last guard
- add regression coverage for the coordinate examples from #166

Fixes #166.

## Tests
- pytest -q