### PR TITLE
Add Python 3.14 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python: ["3.10", "3.11", "3.12", "3.13"]
+        python: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v4

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-pytest>=6, <7
+pytest>=8, <9
 flake8
 mock
 pytest-cov

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,5 @@
-from _pytest.mark import Mark
-
-
-empty_mark = Mark("", [], {})
-
-
 def by_slow_marker(item):
-    return item.get_closest_marker("slow", default=empty_mark)
+    return item.get_closest_marker("slow") is not None
 
 
 def pytest_collection_modifyitems(items):

--- a/tests/test_autocrop.py
+++ b/tests/test_autocrop.py
@@ -16,16 +16,14 @@ def integration():
     path_i = "tests/test"
     path_o = "tests/crop"
     path_r = "tests/reject"
+    for path in [path_i, path_o, path_r]:
+        shutil.rmtree(path, ignore_errors=True)
     shutil.copytree("tests/data", path_i)
     yield
 
     # Teardown
-    shutil.rmtree(path_i)
-    for path in [path_o, path_r]:
-        try:
-            shutil.rmtree(path)
-        except OSError:
-            pass
+    for path in [path_i, path_o, path_r]:
+        shutil.rmtree(path, ignore_errors=True)
 
 
 def test_gamma_brightens_image():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -21,16 +21,14 @@ def integration():
     path_i = "tests/test"
     path_o = "tests/crop"
     path_r = "tests/reject"
+    for path in [path_i, path_o, path_r]:
+        shutil.rmtree(path, ignore_errors=True)
     shutil.copytree("tests/data", path_i)
     yield
 
     # Teardown
-    shutil.rmtree(path_i)
-    for path in [path_o, path_r]:
-        try:
-            shutil.rmtree(path)
-        except OSError:
-            pass
+    for path in [path_i, path_o, path_r]:
+        shutil.rmtree(path, ignore_errors=True)
 
 
 def test_size_140_is_valid():


### PR DESCRIPTION
## Summary
- add Python 3.14 to the CI matrix
- update pytest to 8.x so tests run under Python 3.14
- make slow-test sorting and integration fixture cleanup compatible with current pytest/repeated local runs

## Tests
- Python 3.13: make lint && pytest --cov autocrop -q --cov-report term-missing
- Python 3.14: make lint && pytest --cov autocrop -q --cov-report term-missing