### PR TITLE
Allow pytest 9 in dev requirements

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-pytest>=8, <9
+pytest>=9.0.3, <10
 flake8
 mock
 pytest-cov


### PR DESCRIPTION
## Summary
- update the dev pytest constraint to allow the security-fixed pytest 9 line
- keep the next-major upper bound in place for future pytest releases

This addresses the Dependabot failure in https://github.com/leblancfg/autocrop/actions/runs/28290213135 where the security updater could not remediate the pytest advisory under the existing pytest <9 constraint.

## Tests
- pytest -q
- git diff --check