### PR TITLE
Fix 1.3.1 release metadata

### DIFF
--- a/autocrop/__version__.py
+++ b/autocrop/__version__.py
@@ -1,4 +1,4 @@
 __title__ = "autocrop"
 __description__ = "Automatically crops faces from batches of pictures"
 __author__ = "François Leblanc"
-__version__ = "1.3.0"
+__version__ = "1.3.1"

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+* Add `--skip-prompt` as a synonym for `--no-confirm`.
+
+### Changed
+* Use Pillow for resizing.
+* Update contributor setup documentation.
+* Update GitHub Actions versions and CI support through Python 3.14.
+* Allow pytest 9 in development requirements.
+
+### Fixed
+* Open files through Pillow to handle transparency.
+* Preserve RGB channels for path inputs.
+* Keep crop positions inside image bounds.
+
 ## 1.3.1 - 2022-02-08
 ### API Additions
 * The `Cropper` class now accepts a `resize` arg, to determine whether to resize the image after cropping it or not.


### PR DESCRIPTION
## Summary
- set the package version metadata to the already-documented `1.3.1` release
- add an `Unreleased` changelog section for changes already merged after the 2022 `1.3.1` entry

Closes #177.

## Checks
- `python3 setup.py --version` -> `1.3.1`
- `.venv/bin/python - <<'PY' ...` confirmed `autocrop.__version__` and installed package metadata are both `1.3.1`
- `.venv/bin/python -m pytest -q` -> `59 passed`
- `git diff --check`

## Notes
- This does not create a GitHub release or publish to PyPI.
- `master` already contains unreleased work after the 2022 `1.3.1` changelog entry, so this PR keeps that work under `Unreleased` rather than assigning it to `1.3.1`.
