### PR TITLE
Preserve CLI output file metadata

### DIFF
--- a/autocrop/cli.py
+++ b/autocrop/cli.py
@@ -1,6 +1,7 @@
 import argparse
 import os
 import shutil
+import stat
 import sys
 from typing import Optional
 
@@ -14,11 +15,24 @@ from .constants import (
 )
 
 
-def output(input_filename, output_filename, image):
+def _preserve_metadata(input_filename, output_filename, source_stat):
+    """Preserve safe filesystem metadata from the source image."""
+    if input_filename != output_filename:
+        shutil.copystat(input_filename, output_filename)
+    os.chmod(output_filename, stat.S_IMODE(source_stat.st_mode))
+    os.utime(
+        output_filename,
+        ns=(source_stat.st_atime_ns, source_stat.st_mtime_ns),
+    )
+
+
+def output(input_filename, output_filename, image, source_stat=None):
     """
     Move the input file to the output location and write over it with the
     cropped image data.
     """
+    if source_stat is None:
+        source_stat = os.stat(input_filename)
     if input_filename != output_filename:
         # Move the file to the output directory
         shutil.copy(input_filename, output_filename)
@@ -27,13 +41,17 @@ def output(input_filename, output_filename, image):
     # Write the new image (converting the format to match the output
     # filename if necessary)
     img_new.save(output_filename)
+    _preserve_metadata(input_filename, output_filename, source_stat)
 
 
-def reject(input_filename, reject_filename):
+def reject(input_filename, reject_filename, source_stat=None):
     """Move the input file to the reject location."""
+    if source_stat is None:
+        source_stat = os.stat(input_filename)
     if input_filename != reject_filename:
         # Move the file to the reject directory
         shutil.copy(input_filename, reject_filename)
+    _preserve_metadata(input_filename, reject_filename, source_stat)
 
 
 def main(
@@ -109,6 +127,7 @@ def main(
             output_filename = os.path.join(output_d, basename)
         reject_filename = os.path.join(reject_d, basename)
         image = None
+        source_stat = os.stat(input_filename)
 
         # Attempt the crop
         try:
@@ -119,11 +138,11 @@ def main(
 
         # Did the crop produce an invalid image?
         if isinstance(image, type(None)):
-            reject(input_filename, reject_filename)
+            reject(input_filename, reject_filename, source_stat)
             print("No face detected: {}".format(reject_filename))
             reject_count += 1
         else:
-            output(input_filename, output_filename, image)
+            output(input_filename, output_filename, image, source_stat)
             print("Face detected:    {}".format(output_filename))
             output_count += 1
 

--- a/autocrop/cli.py
+++ b/autocrop/cli.py
@@ -26,6 +26,17 @@ def _preserve_metadata(input_filename, output_filename, source_stat):
     )
 
 
+def _image_save_kwargs(input_filename):
+    """Return image metadata Pillow can preserve while writing the crop."""
+    save_kwargs = {}
+    with Image.open(input_filename) as img_orig:
+        if "exif" in img_orig.info:
+            save_kwargs["exif"] = img_orig.info["exif"]
+        if "icc_profile" in img_orig.info:
+            save_kwargs["icc_profile"] = img_orig.info["icc_profile"]
+    return save_kwargs
+
+
 def output(input_filename, output_filename, image, source_stat=None):
     """
     Move the input file to the output location and write over it with the
@@ -36,11 +47,12 @@ def output(input_filename, output_filename, image, source_stat=None):
     if input_filename != output_filename:
         # Move the file to the output directory
         shutil.copy(input_filename, output_filename)
+    save_kwargs = _image_save_kwargs(input_filename)
     # Encode the image as an in-memory PNG
     img_new = Image.fromarray(image)
     # Write the new image (converting the format to match the output
     # filename if necessary)
-    img_new.save(output_filename)
+    img_new.save(output_filename, **save_kwargs)
     _preserve_metadata(input_filename, output_filename, source_stat)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,12 +7,24 @@ import sys
 
 import pytest
 import cv2
+import numpy as np
 from unittest import mock
+from PIL import Image
 
 from autocrop.autocrop import Cropper
-from autocrop.cli import command_line_interface, main, size, confirmation, chk_extension
+from autocrop.cli import (
+    command_line_interface,
+    main,
+    output,
+    reject,
+    size,
+    confirmation,
+    chk_extension,
+)
 
 NUM_FILES = 12
+SOURCE_ATIME_NS = 946684800123456000
+SOURCE_MTIME_NS = 978307200654321000
 
 
 @pytest.fixture()
@@ -58,6 +70,55 @@ def test_size_minus_14_not_valid():
         size(-14)
         print(e)
     assert "Invalid pixel" in str(e)
+
+
+def set_source_timestamps(path):
+    os.utime(path, ns=(SOURCE_ATIME_NS, SOURCE_MTIME_NS))
+    return os.stat(path)
+
+
+def assert_timestamps_match_source(path):
+    metadata = os.stat(path)
+    assert metadata.st_atime_ns == SOURCE_ATIME_NS
+    assert metadata.st_mtime_ns == SOURCE_MTIME_NS
+
+
+def test_output_preserves_source_timestamps_for_new_file(tmp_path):
+    source = tmp_path / "source.jpg"
+    destination = tmp_path / "destination.jpg"
+    Image.new("RGB", (4, 4), "red").save(source)
+    source_stat = set_source_timestamps(source)
+
+    image = np.full((2, 2, 3), 255, dtype=np.uint8)
+    output(str(source), str(destination), image, source_stat)
+
+    assert_timestamps_match_source(destination)
+    with Image.open(destination) as result:
+        assert result.size == (2, 2)
+
+
+def test_output_preserves_source_timestamps_when_overwriting(tmp_path):
+    source = tmp_path / "source.jpg"
+    Image.new("RGB", (4, 4), "red").save(source)
+    source_stat = set_source_timestamps(source)
+
+    image = np.full((2, 2, 3), 255, dtype=np.uint8)
+    output(str(source), str(source), image, source_stat)
+
+    assert_timestamps_match_source(source)
+    with Image.open(source) as result:
+        assert result.size == (2, 2)
+
+
+def test_reject_preserves_source_timestamps_for_new_file(tmp_path):
+    source = tmp_path / "source.jpg"
+    destination = tmp_path / "reject.jpg"
+    Image.new("RGB", (4, 4), "red").save(source)
+    source_stat = set_source_timestamps(source)
+
+    reject(str(source), str(destination), source_stat)
+
+    assert_timestamps_match_source(destination)
 
 
 @mock.patch("autocrop.cli.input_path", lambda p: p)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25,6 +25,7 @@ from autocrop.cli import (
 NUM_FILES = 12
 SOURCE_ATIME_NS = 946684800123456000
 SOURCE_MTIME_NS = 978307200654321000
+EXIF_MAKE_TAG = 271
 
 
 @pytest.fixture()
@@ -83,6 +84,19 @@ def assert_timestamps_match_source(path):
     assert metadata.st_mtime_ns == SOURCE_MTIME_NS
 
 
+def exif_image(path):
+    exif = Image.Exif()
+    exif[EXIF_MAKE_TAG] = "autocrop-test-camera"
+    Image.new("RGB", (4, 4), "red").save(path, exif=exif)
+
+
+def assert_exif_matches_source(source, destination):
+    with Image.open(source) as source_image, Image.open(destination) as result_image:
+        assert result_image.getexif()[EXIF_MAKE_TAG] == source_image.getexif()[
+            EXIF_MAKE_TAG
+        ]
+
+
 def test_output_preserves_source_timestamps_for_new_file(tmp_path):
     source = tmp_path / "source.jpg"
     destination = tmp_path / "destination.jpg"
@@ -97,6 +111,19 @@ def test_output_preserves_source_timestamps_for_new_file(tmp_path):
         assert result.size == (2, 2)
 
 
+def test_output_preserves_exif_for_new_file(tmp_path):
+    source = tmp_path / "source.jpg"
+    destination = tmp_path / "destination.jpg"
+    exif_image(source)
+
+    image = np.full((2, 2, 3), 255, dtype=np.uint8)
+    output(str(source), str(destination), image)
+
+    assert_exif_matches_source(source, destination)
+    with Image.open(destination) as result:
+        assert result.size == (2, 2)
+
+
 def test_output_preserves_source_timestamps_when_overwriting(tmp_path):
     source = tmp_path / "source.jpg"
     Image.new("RGB", (4, 4), "red").save(source)
@@ -107,6 +134,18 @@ def test_output_preserves_source_timestamps_when_overwriting(tmp_path):
 
     assert_timestamps_match_source(source)
     with Image.open(source) as result:
+        assert result.size == (2, 2)
+
+
+def test_output_preserves_exif_when_overwriting(tmp_path):
+    source = tmp_path / "source.jpg"
+    exif_image(source)
+
+    image = np.full((2, 2, 3), 255, dtype=np.uint8)
+    output(str(source), str(source), image)
+
+    with Image.open(source) as result:
+        assert result.getexif()[EXIF_MAKE_TAG] == "autocrop-test-camera"
         assert result.size == (2, 2)
 
 


### PR DESCRIPTION
## Summary
- snapshot source file metadata before cropping reads the image
- restore safe filesystem metadata on cropped CLI outputs and reject copies
- preserve mtime/atime for in-place overwrites where the output path is the source file
- preserve embedded image metadata Pillow can safely carry forward on cropped outputs, including EXIF and ICC profile data

Closes #56.

## Tests
- `pytest tests/test_cli.py -q`
- `flake8 --max-complexity=10 --count autocrop tests`
- `git diff --check`
- `pytest -q`

## Caveat
- Portable standard-library preservation covers timestamps and permission bits; platform-specific creation/birth time is not generally writable from Python standard library APIs.
- Embedded metadata preservation is best-effort through Pillow save kwargs and depends on output format support.
