### PR TITLE
v2 composable CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,23 +42,24 @@ Further examples and use cases are found in the [accompanying Jupyter Notebook](
 
     usage: autocrop [-h] [-v] [--no-confirm] [-n] [-i INPUT] [-o OUTPUT] [-r REJECT] [-w WIDTH] [-H HEIGHT] [--facePercent FACEPERCENT]
                     [-e EXTENSION]
+                    [source]
 
-    Automatically crops faces from batches of pictures
+    Automatically crops faces from pictures
 
     options:
+      source                Image file, image directory, or '-' to read image bytes from stdin. Directory input requires --output.
       -h, --help            Show this help message and exit
       -v, --version         Show program's version number and exit
       --no-confirm, --skip-prompt
                             Bypass any confirmation prompts
       -n, --no-resize       Do not resize images to the specified width and height, but instead use the original image's pixels.
       -i, --input INPUT
-                            Folder where images to crop are located. Default: current working directory
+                            Image file or folder where images to crop are located. Use '-' to read image bytes from stdin.
       -o, -p, --output, --path OUTPUT
-                            Folder where cropped images will be moved to. Default: current working directory, meaning images are cropped in
-                            place.
+                            Output file for a single input image, or output directory for directory input. If omitted for a single image,
+                            cropped image bytes are written to stdout.
       -r, --reject REJECT
-                            Folder where images that could not be cropped will be moved to. Default: current working directory, meaning images
-                            that are not cropped will be left in place.
+                            Folder where images that could not be cropped will be moved to in directory mode.
       -w, --width WIDTH
                             Width of cropped files in px. Default=500
       -H, --height HEIGHT
@@ -70,6 +71,15 @@ Further examples and use cases are found in the [accompanying Jupyter Notebook](
 
 ### Examples
 
+* Crop one image and write the cropped image bytes to stdout:
+    - `autocrop portrait.jpg > cropped.jpg`
+* Crop image bytes from stdin. This uses `-` instead of `--` because `--` is already argparse's standard option terminator:
+    - `cat portrait.jpg | autocrop - > cropped.jpg`
+    - `autocrop -- > cropped.jpg < portrait.jpg`
+* Crop one image and write to an explicit output file:
+    - `autocrop portrait.jpg -o cropped.jpg`
+* Crop one image and write into an explicit output directory:
+    - `autocrop portrait.jpg -o crop`
 * Crop every image in the `pics` folder, resize them to 400 px squares, and output them in the `crop` directory:
 	- `autocrop -i pics -o crop -w 400 -H 400`.
 	- Images where a face can't be detected will be left in `crop`.
@@ -79,8 +89,44 @@ Further examples and use cases are found in the [accompanying Jupyter Notebook](
 	- `autocrop -i pics -o crop -w 400 -H 400 -e png`
 * Crop every image in the `pics` folder and output to the `crop` directory, but keep the original pixels from the images:
     - `autocrop -i pics -o crop --no-resize`
-	
-If no output folder is added, asks for confirmation and destructively crops images in-place.
+
+Directory input now requires an explicit output directory. For recursive or filtered batch workflows, compose `autocrop` with shell tools instead of relying on implicit whole-folder behavior. Successful single-image and stdin runs are quiet except for cropped image bytes on stdout; diagnostics are written to stderr.
+
+```sh
+mkdir -p crop
+find pics -type f \( -iname '*.jpg' -o -iname '*.png' \) -print0 |
+  while IFS= read -r -d '' file; do
+    out="crop/${file#pics/}"
+    mkdir -p "$(dirname "$out")"
+    autocrop "$file" -e jpg > "${out%.*}.jpg"
+  done
+```
+
+With [`fd`](https://github.com/sharkdp/fd):
+
+```sh
+fd -e jpg -e png . pics -x sh -c 'out="crop/${1#pics/}"; mkdir -p "$(dirname "$out")"; autocrop "$1" -e jpg > "${out%.*}.jpg"' sh {}
+```
+
+With `xargs`:
+
+```sh
+find pics -type f \( -iname '*.jpg' -o -iname '*.png' \) -print0 |
+  xargs -0 -I{} sh -c 'out="crop/${1#pics/}"; mkdir -p "$(dirname "$out")"; autocrop "$1" > "$out"' sh {}
+```
+
+With GNU `parallel`:
+
+```sh
+find pics -type f \( -iname '*.jpg' -o -iname '*.png' \) -print0 |
+  parallel -0 'out="crop/{= s:^pics/:: =}"; mkdir -p "$(dirname "$out")"; autocrop {} > "$out"'
+```
+
+Explicit in-place directory output remains available by passing the same input and output directory, and still prompts unless `--no-confirm` is used:
+
+```sh
+autocrop -i pics -o pics
+```
 
 ### Detecting faces from video files
 You can use autocrop to detect faces in frames extracted from a video. A great way to [perform the frame extraction step is with `ffmpeg`](https://ffmpeg.org/download.html):

--- a/autocrop/cli.py
+++ b/autocrop/cli.py
@@ -1,10 +1,12 @@
 import argparse
+import io
 import os
 import shutil
 import stat
 import sys
 from typing import Optional
 
+import numpy as np
 from PIL import Image
 
 from .__version__ import __version__
@@ -56,6 +58,12 @@ def output(input_filename, output_filename, image, source_stat=None):
     _preserve_metadata(input_filename, output_filename, source_stat)
 
 
+def output_bytes(image, output_stream, image_format):
+    """Write cropped image bytes to a binary stream."""
+    img_new = Image.fromarray(image)
+    img_new.save(output_stream, format=image_format)
+
+
 def reject(input_filename, reject_filename, source_stat=None):
     """Move the input file to the reject location."""
     if source_stat is None:
@@ -64,6 +72,12 @@ def reject(input_filename, reject_filename, source_stat=None):
         # Move the file to the reject directory
         shutil.copy(input_filename, reject_filename)
     _preserve_metadata(input_filename, reject_filename, source_stat)
+
+
+def status(message, quiet):
+    """Write status text to stderr unless quiet mode is enabled."""
+    if not quiet:
+        print(message, file=sys.stderr)
 
 
 def main(
@@ -75,6 +89,7 @@ def main(
     fwidth: int = 500,
     facePercent: int = 50,
     resize: bool = True,
+    quiet: bool = True,
 ) -> None:
     """
     Crops folder of images to the desired height and width if a
@@ -145,38 +160,45 @@ def main(
         try:
             image = cropper.crop(input_filename)
         except ImageReadError:
-            print("Read error:       {}".format(input_filename))
+            status("Read error:       {}".format(input_filename), quiet)
             continue
 
         # Did the crop produce an invalid image?
         if isinstance(image, type(None)):
             reject(input_filename, reject_filename, source_stat)
-            print("No face detected: {}".format(reject_filename))
+            status("No face detected: {}".format(reject_filename), quiet)
             reject_count += 1
         else:
             output(input_filename, output_filename, image, source_stat)
-            print("Face detected:    {}".format(output_filename))
+            status("Face detected:    {}".format(output_filename), quiet)
             output_count += 1
 
     # Stop and print status
 
-    print(
-        f"{input_count} : Input files, {output_count} : Faces Cropped, {reject_count}"
+    status(
+        f"{input_count} : Input files, {output_count} : Faces Cropped, {reject_count}",
+        quiet,
     )
 
 
 def input_path(p):
-    """Returns path, only if input is a valid directory."""
-    no_folder = "Input folder does not exist"
+    """Return path, only if input is a valid image file, directory, or stdin."""
+    no_folder = "Input path does not exist"
     no_images = "Input folder does not contain any image files"
-    p = os.path.abspath(p)
-    if not os.path.isdir(p):
-        raise argparse.ArgumentTypeError(no_folder)
-    filetypes = {os.path.splitext(f)[-1] for f in os.listdir(p)}
-    if not any(t in INPUT_FILETYPES for t in filetypes):
-        raise argparse.ArgumentTypeError(no_images)
-    else:
+    no_image_file = "Input file type is not supported"
+    if p == "-":
         return p
+    p = os.path.abspath(p)
+    if not os.path.exists(p):
+        raise argparse.ArgumentTypeError(no_folder)
+    if os.path.isdir(p):
+        filetypes = {os.path.splitext(f)[-1] for f in os.listdir(p)}
+        if not any(t in INPUT_FILETYPES for t in filetypes):
+            raise argparse.ArgumentTypeError(no_images)
+        return p
+    if os.path.splitext(p)[-1] not in INPUT_FILETYPES:
+        raise argparse.ArgumentTypeError(no_image_file)
+    return p
 
 
 def output_path(p):
@@ -245,21 +267,117 @@ def chk_extension(extension):
         raise argparse.ArgumentTypeError(error)
 
 
+def output_format(input_format=None, extension=None):
+    """Return a Pillow format name for stream or file output."""
+    if extension:
+        return Image.registered_extensions()[f".{extension}"]
+    return input_format or "PNG"
+
+
+def crop_image(
+    path_or_array, image_format, extension, fheight, fwidth, face_percent, resize
+):
+    """Crop a single image path or numpy array."""
+    cropper = Cropper(
+        width=fwidth, height=fheight, face_percent=face_percent, resize=resize
+    )
+    image = cropper.crop(path_or_array)
+    if image is None:
+        return None, None
+    return image, output_format(image_format, extension)
+
+
+def cropper_array_from_pillow_image(img_orig):
+    """
+    Return an array in the color-channel order expected by Cropper.crop(np.ndarray).
+
+    Cropper treats ndarray inputs as OpenCV-style BGR/BGRA and converts them back
+    to RGB/RGBA before returning. Pillow decodes stream input as RGB/RGBA, so swap
+    the first and third channels up front to keep stdin output colors stable.
+    """
+    input_image = np.array(img_orig)
+    if input_image.ndim == 3 and input_image.shape[2] >= 3:
+        input_image = input_image.copy()
+        input_image[:, :, [0, 2]] = input_image[:, :, [2, 0]]
+    return input_image
+
+
+def crop_file_to_output(
+    input_filename,
+    output_filename=None,
+    extension=None,
+    fheight=500,
+    fwidth=500,
+    face_percent=50,
+    resize=True,
+    stdout=None,
+):
+    """Crop one image file to a file path or stdout."""
+    with Image.open(input_filename) as img_orig:
+        input_format = img_orig.format
+
+    image, image_format = crop_image(
+        input_filename, input_format, extension, fheight, fwidth, face_percent, resize
+    )
+    if image is None:
+        print(f"No face detected: {input_filename}", file=sys.stderr)
+        return 1
+
+    if output_filename is None:
+        output_bytes(image, stdout or sys.stdout.buffer, image_format)
+    else:
+        output(input_filename, output_filename, image)
+    return 0
+
+
+def crop_stdin_to_stdout(
+    stdin=None,
+    stdout=None,
+    extension=None,
+    fheight=500,
+    fwidth=500,
+    face_percent=50,
+    resize=True,
+):
+    """Read image bytes from stdin, crop, and write image bytes to stdout."""
+    stdin = stdin or sys.stdin.buffer
+    stdout = stdout or sys.stdout.buffer
+    image_bytes = stdin.read()
+    if not image_bytes:
+        print("No image bytes received on stdin", file=sys.stderr)
+        return 1
+
+    try:
+        with Image.open(io.BytesIO(image_bytes)) as img_orig:
+            input_format = img_orig.format
+            input_image = cropper_array_from_pillow_image(img_orig)
+    except OSError as exc:
+        print(f"Could not read image from stdin: {exc}", file=sys.stderr)
+        return 1
+
+    image, image_format = crop_image(
+        input_image, input_format, extension, fheight, fwidth, face_percent, resize
+    )
+    if image is None:
+        print("No face detected on stdin image", file=sys.stderr)
+        return 1
+    output_bytes(image, stdout, image_format)
+    return 0
+
+
 def parse_args(args):
     """Helper function. Parses the arguments given to the CLI."""
     help_d = {
-        "desc": "Automatically crops faces from batches of pictures",
-        "input": """Folder where images to crop are located. Default:
-                     current working directory""",
-        "output": """Folder where cropped images will be moved to.
-
-                      Default: current working directory, meaning images are
-                      cropped in place.""",
+        "desc": "Automatically crops faces from pictures",
+        "source": """Image file, image directory, or '-' to read image bytes from
+                     stdin. Directory input requires --output.""",
+        "input": """Image file or folder where images to crop are located.
+                     Use '-' to read image bytes from stdin.""",
+        "output": """Output file for a single input image, or output directory for
+                      directory input. If omitted for a single image, cropped
+                      image bytes are written to stdout.""",
         "reject": """Folder where images that could not be cropped will be
-                       moved to.
-
-                      Default: current working directory, meaning images that
-                      are not cropped will be left in place.""",
+                       moved to in directory mode.""",
         "extension": "Enter the image extension which to save at output",
         "width": "Width of cropped files in px. Default=500",
         "height": "Height of cropped files in px. Default=500",
@@ -271,6 +389,12 @@ def parse_args(args):
 
     parser = argparse.ArgumentParser(description=help_d["desc"])
     parser.add_argument(
+        "source",
+        nargs="?",
+        type=input_path,
+        help=help_d["source"],
+    )
+    parser.add_argument(
         "-v",
         "--version",
         action="version",
@@ -279,7 +403,8 @@ def parse_args(args):
     parser.add_argument(
         "--no-confirm",
         "--skip-prompt",
-        action="store_true", help=help_d["y"]
+        action="store_true",
+        help=help_d["y"],
     )
     parser.add_argument(
         "-n",
@@ -288,14 +413,13 @@ def parse_args(args):
         help=help_d["no_resize"],
     )
     parser.add_argument(
-        "-i", "--input", default=".", type=input_path, help=help_d["input"]
+        "-i", "--input", default=None, type=input_path, help=help_d["input"]
     )
     parser.add_argument(
         "-o",
         "--output",
         "-p",
         "--path",
-        type=output_path,
         default=None,
         help=help_d["output"],
     )
@@ -311,7 +435,69 @@ def parse_args(args):
         "-e", "--extension", type=chk_extension, default=None, help=help_d["extension"]
     )
 
-    return parser.parse_args()
+    parsed = parser.parse_args(args)
+    if parsed.input is not None and parsed.source is not None:
+        parser.error("use either positional source or --input, not both")
+    return parsed
+
+
+def resolve_file_output(input_source, output_arg, extension):
+    """Resolve --output for single-image mode."""
+    if output_arg is None:
+        return None
+    output_ext = os.path.splitext(output_arg)[1]
+    if os.path.isdir(output_arg) or not output_ext:
+        os.makedirs(output_arg, exist_ok=True)
+        basename = os.path.basename(input_source)
+        if extension:
+            basename = os.path.splitext(basename)[0] + "." + extension
+        return os.path.join(output_arg, basename)
+
+    output_dir = os.path.dirname(os.path.abspath(output_arg))
+    if output_dir:
+        os.makedirs(output_dir, exist_ok=True)
+    return os.path.abspath(output_arg)
+
+
+def run_single_file_mode(args, input_source, resize):
+    """Run single-image file mode."""
+    output_filename = resolve_file_output(input_source, args.output, args.extension)
+    return crop_file_to_output(
+        input_source,
+        output_filename,
+        args.extension,
+        args.height,
+        args.width,
+        args.facePercent,
+        resize,
+    )
+
+
+def run_directory_mode(args, input_source, resize):
+    """Run explicit directory batch mode."""
+    if args.output is None:
+        raise SystemExit(
+            "autocrop: directory input requires --output. "
+            "Use find/fd to stream files one at a time."
+        )
+
+    args.output = output_path(args.output)
+    if not args.no_confirm and input_source == args.output:
+        if not confirmation(QUESTION_OVERWRITE):
+            sys.exit()
+    if input_source == args.output:
+        args.output = None
+    main(
+        input_source,
+        args.output,
+        args.reject,
+        args.extension,
+        args.height,
+        args.width,
+        args.facePercent,
+        resize,
+    )
+    return 0
 
 
 def command_line_interface():
@@ -321,22 +507,28 @@ def command_line_interface():
     Crops faces from batches of images.
     """
     args = parse_args(sys.argv[1:])
-    if not args.no_confirm:
-        if args.output is None or args.input == args.output:
-            if not confirmation(QUESTION_OVERWRITE):
-                sys.exit()
-    if args.input == args.output:
-        args.output = None
-    print("Processing images in folder:", args.input)
+    input_source = args.input or args.source
+    if input_source is None:
+        if sys.stdin.isatty():
+            raise SystemExit(
+                "autocrop: an input image, input directory, or '-' is required"
+            )
+        input_source = "-"
 
     resize = not args.no_resize
-    main(
-        args.input,
-        args.output,
-        args.reject,
-        args.extension,
-        args.height,
-        args.width,
-        args.facePercent,
-        resize,
-    )
+
+    if input_source == "-":
+        status = crop_stdin_to_stdout(
+            extension=args.extension,
+            fheight=args.height,
+            fwidth=args.width,
+            face_percent=args.facePercent,
+            resize=resize,
+        )
+        sys.exit(status)
+
+    if os.path.isfile(input_source):
+        status = run_single_file_mode(args, input_source, resize)
+        sys.exit(status)
+
+    run_directory_mode(args, input_source, resize)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,9 +14,13 @@ from PIL import Image
 from autocrop.autocrop import Cropper
 from autocrop.cli import (
     command_line_interface,
+    crop_file_to_output,
+    crop_stdin_to_stdout,
     main,
     output,
+    output_format,
     reject,
+    resolve_file_output,
     size,
     confirmation,
     chk_extension,
@@ -160,24 +164,61 @@ def test_reject_preserves_source_timestamps_for_new_file(tmp_path):
     assert_timestamps_match_source(destination)
 
 
-@mock.patch("autocrop.cli.input_path", lambda p: p)
 @mock.patch("autocrop.cli.main")
-def test_cli_no_args_means_cwd(mock_main):
+def test_cli_no_args_requires_input_from_tty(mock_main, monkeypatch):
     mock_main.return_value = None
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
     sys.argv = ["", "--no-confirm"]
-    command_line_interface()
-    args, _ = mock_main.call_args
-    assert args == (".", None, None, None, 500, 500, 50, True)
-
-
-@mock.patch("autocrop.cli.input_path", lambda p: p)
-@mock.patch("autocrop.cli.main")
-def test_cli_width_140_is_valid(mock_main):
-    mock_main.return_value = None
-    sys.argv = ["autocrop", "-w", "140", "--no-confirm"]
+    with pytest.raises(SystemExit) as e:
+        command_line_interface()
+    assert "input image" in str(e.value)
     assert mock_main.call_count == 0
-    command_line_interface()
-    assert mock_main.call_count == 1
+
+
+@mock.patch("autocrop.cli.crop_file_to_output")
+def test_cli_file_without_output_writes_to_stdout(mock_crop):
+    mock_crop.return_value = 0
+    sys.argv = ["autocrop", "tests/data/obama.jpg"]
+    with pytest.raises(SystemExit) as e:
+        command_line_interface()
+    assert e.value.code == 0
+    args, _ = mock_crop.call_args
+    assert args[0].endswith("tests/data/obama.jpg")
+    assert args[1] is None
+
+
+@mock.patch("autocrop.cli.crop_stdin_to_stdout")
+def test_cli_dash_reads_stdin_and_writes_stdout(mock_crop):
+    mock_crop.return_value = 0
+    sys.argv = ["autocrop", "-"]
+    with pytest.raises(SystemExit) as e:
+        command_line_interface()
+    assert e.value.code == 0
+    assert mock_crop.call_count == 1
+
+
+@mock.patch("autocrop.cli.crop_stdin_to_stdout")
+def test_cli_no_args_reads_stdin_when_input_is_piped(mock_crop, monkeypatch):
+    mock_crop.return_value = 0
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+    sys.argv = ["autocrop"]
+    with pytest.raises(SystemExit) as e:
+        command_line_interface()
+    assert e.value.code == 0
+    assert mock_crop.call_count == 1
+
+
+@mock.patch("autocrop.cli.crop_file_to_output")
+def test_cli_width_140_is_valid(mock_crop):
+    mock_crop.return_value = 0
+    sys.argv = ["autocrop", "tests/data/obama.jpg", "-w", "140", "--no-confirm"]
+    assert mock_crop.call_count == 0
+    with pytest.raises(SystemExit) as e:
+        command_line_interface()
+    assert e.value.code == 0
+    assert mock_crop.call_count == 1
+    args, _ = mock_crop.call_args
+    assert args[4] == 140
 
 
 def test_cli_invalid_input_path_errors_out():
@@ -233,21 +274,22 @@ def test_confirmation_get_from_user(from_user, response, output):
 
 @mock.patch("autocrop.cli.main", lambda *args: None)
 @mock.patch("autocrop.cli.confirmation")
-def test_user_gets_prompted_if_no_output_is_given(mock_confirm):
+def test_directory_input_without_output_errors(mock_confirm):
     mock_confirm.return_value = False
     sys.argv = ["", "-i", "tests/data"]
     with pytest.raises(SystemExit) as e:
         assert mock_confirm.call_count == 0
         command_line_interface()
-    assert mock_confirm.call_count == 1
+    assert mock_confirm.call_count == 0
     assert e.type == SystemExit
+    assert "directory input requires --output" in str(e.value)
 
 
 @mock.patch("autocrop.cli.main", lambda *args: None)
 @mock.patch("autocrop.cli.confirmation")
 def test_user_gets_prompted_if_output_same_as_input(mock_confirm):
     mock_confirm.return_value = False
-    sys.argv = ["", "-i", "tests/data"]
+    sys.argv = ["", "-i", "tests/data", "-o", "tests/data"]
     with pytest.raises(SystemExit) as e:
         assert mock_confirm.call_count == 0
         command_line_interface()
@@ -301,7 +343,7 @@ def test_user_does_not_get_prompted_if_output_d_is_given(mock_confirm):
 )
 def test_user_does_not_get_prompted_if_no_confirm(mock_confirm, flag):
     mock_confirm.return_value = False
-    sys.argv = ["", "-i", "tests/data", flag]
+    sys.argv = ["", "-i", "tests/data", "-o", "tests/crop", flag]
     assert mock_confirm.call_count == 0
     command_line_interface()
     assert mock_confirm.call_count == 0
@@ -336,10 +378,10 @@ def test_nofaces_copied_to_reject_d_if_both_reject_and_output_d(integration):
 @pytest.mark.slow
 @mock.patch("autocrop.cli.confirmation", lambda *args: True)
 def test_image_files_overwritten_if_no_output_dir(integration):
-    sys.argv = ["", "-i", "tests/test"]
+    sys.argv = ["", "-i", "tests/test", "-o", "tests/test"]
     command_line_interface()
     # We have the same number of files
-    output_files = os.listdir(sys.argv[-1])
+    output_files = os.listdir("tests/test")
     assert len(output_files) == NUM_FILES
     # Images with a face have been cropped
     shape = cv2.imread("tests/test/king.jpg").shape
@@ -362,6 +404,15 @@ def test_check_extension(extension, error_expected, expected):
         pytest.raises(argparse.ArgumentTypeError, chk_extension, extension)
     else:
         assert chk_extension(extension) == expected
+
+
+def test_output_format_uses_pillow_format_name_for_extensions():
+    assert output_format("PNG", "jpg") == "JPEG"
+
+
+def test_resolve_file_output_keeps_output_directory_behavior(tmp_path):
+    output_filename = resolve_file_output("tests/data/obama.jpg", str(tmp_path), None)
+    assert output_filename == os.path.join(str(tmp_path), "obama.jpg")
 
 
 @pytest.mark.slow
@@ -396,3 +447,67 @@ def test_no_resize_flag(integration):
     command_line_interface()
     img = cv2.imread("tests/crop/obama.jpg")
     assert img.shape == (430, 430, 3)
+
+
+def test_crop_file_to_output_writes_cropped_bytes_to_stdout(monkeypatch, capsys):
+    image = Image.open("tests/data/obama.jpg")
+    cropped = image.resize((32, 32))
+    stdout = io.BytesIO()
+    monkeypatch.setattr(Cropper, "crop", lambda *args: np.array(cropped))
+
+    status = crop_file_to_output(
+        "tests/data/obama.jpg",
+        stdout=stdout,
+        fheight=32,
+        fwidth=32,
+    )
+
+    stdout.seek(0)
+    with Image.open(stdout) as result:
+        assert status == 0
+        assert result.size == (32, 32)
+        assert result.format == "JPEG"
+    assert capsys.readouterr().err == ""
+
+
+def test_crop_file_to_output_writes_failures_to_stderr(monkeypatch, capsys):
+    stdout = io.BytesIO()
+    monkeypatch.setattr(Cropper, "crop", lambda *args: None)
+
+    status = crop_file_to_output("tests/data/noise.png", stdout=stdout)
+
+    captured = capsys.readouterr()
+    assert status == 1
+    assert stdout.getvalue() == b""
+    assert captured.out == ""
+    assert "No face detected: tests/data/noise.png" in captured.err
+
+
+def test_crop_stdin_to_stdout_infers_image_type(monkeypatch):
+    source = io.BytesIO()
+    Image.new("RGB", (40, 40), "white").save(source, format="PNG")
+    source.seek(0)
+    stdout = io.BytesIO()
+    monkeypatch.setattr(
+        Cropper, "crop", lambda *args: np.array(Image.new("RGB", (20, 20), "white"))
+    )
+
+    status = crop_stdin_to_stdout(stdin=source, stdout=stdout)
+
+    stdout.seek(0)
+    with Image.open(stdout) as result:
+        assert status == 0
+        assert result.size == (20, 20)
+        assert result.format == "PNG"
+
+
+def test_crop_stdin_to_stdout_writes_invalid_input_to_stderr(capsys):
+    stdout = io.BytesIO()
+
+    status = crop_stdin_to_stdout(stdin=io.BytesIO(b"not an image"), stdout=stdout)
+
+    captured = capsys.readouterr()
+    assert status == 1
+    assert stdout.getvalue() == b""
+    assert captured.out == ""
+    assert "Could not read image from stdin" in captured.err


### PR DESCRIPTION
## Summary

Draft implementation for #194.

- allows single-image input as a positional argument
- writes cropped image bytes to stdout when no output path is provided
- supports stdin image bytes with `-` or implicit piped stdin
- keeps explicit directory mode, but requires `--output` for directory input
- moves status/failure text to stderr for pipeable stdout behavior
- updates README examples toward `find`, `fd`, `xargs`, and `parallel`

## Notes for review

This is intentionally a v2 contract draft. It changes old no-argument behavior and makes directory input without `--output` an error. The branch also uses `-` for stdin; plain `--` works as argparse's option terminator before implicit stdin redirection, but is not itself an input token.

## Verification

- `pytest tests/test_cli.py -q` passed, 42 tests
- `flake8 --max-complexity=10 --count autocrop tests` passed
- `git diff --check` passed

Closes #194 when finalized.
