### PR TITLE
Fix CLI path assertion on Windows

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -183,7 +183,7 @@ def test_cli_file_without_output_writes_to_stdout(mock_crop):
         command_line_interface()
     assert e.value.code == 0
     args, _ = mock_crop.call_args
-    assert args[0].endswith("tests/data/obama.jpg")
+    assert args[0].replace("\\", "/").endswith("tests/data/obama.jpg")
     assert args[1] is None
 
 


### PR DESCRIPTION
## Summary

- normalize the CLI path assertion in `test_cli_file_without_output_writes_to_stdout`
- keep the CLI behavior unchanged

## Why

The `master` CI run failed only on Windows because the test expected a POSIX-style suffix:

`tests/data/obama.jpg`

On Windows, argparse resolves the source path to an absolute path with backslashes:

`D:\a\autocrop\autocrop\tests\data\obama.jpg`

## Verification

- `uv run --with-requirements requirements-dev.txt --with-editable . pytest tests/test_cli.py -q`
- `uv run --with-requirements requirements-dev.txt --with-editable . flake8 --max-complexity=10 --count autocrop tests`
- `uv run --with-requirements requirements-dev.txt --with-editable . pytest -q`
- `git diff --check`

Failure run: https://github.com/leblancfg/autocrop/actions/runs/28388381981
