### PR TITLE
docs: refresh autocrop logo assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # autocrop
 
+<p align="center">
+  <img src="docs/assets/social-preview.svg" alt="autocrop: crop images around faces from Python or the shell" width="760">
+</p>
+
 [![CI](https://github.com/leblancfg/autocrop/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/leblancfg/autocrop/actions/workflows/ci.yml) [![Documentation](https://img.shields.io/badge/docs-passing-success.svg)](https://leblancfg.com/autocrop) [![PyPI version](https://badge.fury.io/py/autocrop.svg)](https://badge.fury.io/py/autocrop) [![Downloads](https://pepy.tech/badge/autocrop)](https://pepy.tech/project/autocrop)
 
 <p align="center"><img title="obama_crop" src="https://cloud.githubusercontent.com/assets/15659410/10975709/3e38de48-83b6-11e5-8885-d95da758ca17.png"></p>

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -7,6 +7,12 @@
     <title>{% if page.title %}{{ page.title | escape }} | {% endif %}{{ site.title | escape }}</title>
     <meta name="description" content="{{ page.description | default: site.description | escape }}" />
     <meta name="author" content="François Leblanc" />
+    <meta property="og:title" content="{% if page.title %}{{ page.title | escape }} | {% endif %}{{ site.title | escape }}" />
+    <meta property="og:description" content="{{ page.description | default: site.description | escape }}" />
+    <meta property="og:type" content="website" />
+    <meta property="og:image" content="{{ '/assets/social-preview.svg' | absolute_url }}" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:image" content="{{ '/assets/social-preview.svg' | absolute_url }}" />
     <link rel="canonical" href="{{ page.url | absolute_url }}" />
     <link rel="icon" href="{{ '/assets/favicon.svg' | relative_url }}" type="image/svg+xml" />
     <link rel="stylesheet" href="{{ '/assets/styles.css' | relative_url }}" />
@@ -16,7 +22,7 @@
       <header class="site-header">
         <div class="header-top">
           <a class="brand-mark" href="{{ '/' | relative_url }}" aria-label="autocrop home">
-            <span aria-hidden="true"></span>
+            <img src="{{ '/assets/autocrop-logo.svg' | relative_url }}" alt="" width="54" height="54" />
           </a>
           <nav class="project-links" aria-label="Project links">
             <a href="https://github.com/leblancfg/autocrop">GitHub</a>

--- a/docs/assets/autocrop-logo.svg
+++ b/docs/assets/autocrop-logo.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-labelledby="title desc">
+  <title id="title">autocrop logo</title>
+  <desc id="desc">A filled face silhouette framed by crop marks in each corner.</desc>
+  <g fill="none" stroke="#24435A" stroke-linecap="square" stroke-linejoin="round">
+    <path d="M20 43V20h23M85 20h23v23M108 85v23H85M43 108H20V85" stroke-width="8"/>
+  </g>
+  <circle cx="64" cy="55" r="22" fill="#24435A"/>
+  <path fill="#24435A" d="M29 108c5.5-19.5 18.2-30 35-30s29.5 10.5 35 30H29Z"/>
+</svg>

--- a/docs/assets/favicon.svg
+++ b/docs/assets/favicon.svg
@@ -1,6 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="autocrop">
   <rect width="64" height="64" rx="14" fill="#E8EAEC"/>
-  <path d="M17 20h30v24H17z" fill="none" stroke="#24435A" stroke-width="4"/>
-  <path d="M24 27h16v10H24z" fill="#24435A"/>
-  <path d="M11 13h14M39 13h14M11 51h14M39 51h14" stroke="#24435A" stroke-width="4" stroke-linecap="round"/>
+  <g fill="none" stroke="#24435A" stroke-linecap="square" stroke-linejoin="round">
+    <path d="M10 21.5V10h11.5M42.5 10H54v11.5M54 42.5V54H42.5M21.5 54H10V42.5" stroke-width="4"/>
+  </g>
+  <circle cx="32" cy="27.5" r="11" fill="#24435A"/>
+  <path fill="#24435A" d="M14.5 54C17.25 44.25 23.6 39 32 39s14.75 5.25 17.5 15h-35Z"/>
 </svg>

--- a/docs/assets/social-preview.svg
+++ b/docs/assets/social-preview.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="640" aria-labelledby="title desc" role="img" viewBox="0 0 1280 640">
+  <title id="title">autocrop</title>
+  <desc id="desc">Crop images around detected faces from Python or the shell.</desc>
+  <style>
+    text{font-family:'Inter',system-ui,-apple-system,'Segoe UI',sans-serif}
+    .mono{font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace}
+    .kicker{font-size:22px;font-weight:600;fill:#6e7268;letter-spacing:4px}
+    .title{font-size:116px;font-weight:800;fill:#1d2933;letter-spacing:-3px}
+    .sub{font-size:33px;font-weight:600;fill:#6e7268}
+    .small{font-size:23px;font-weight:500;fill:#8b8f86}
+    .wordmark{fill:#6e7268;font-size:24px;font-weight:600;letter-spacing:.3px}
+  </style>
+  <rect width="1280" height="640" fill="#ECEBE6"/>
+  <text x="88" y="214" class="kicker mono">FACE-AWARE · FOR PYTHON</text>
+  <text x="84" y="320" class="title">autocrop</text>
+  <text x="90" y="384" class="sub">crop images around faces</text>
+  <text x="90" y="430" class="small">from Python or the shell</text>
+  <g transform="translate(76 532) scale(.375)">
+    <g fill="none" stroke="#24435A" stroke-linecap="square" stroke-linejoin="round">
+      <path d="M20 43V20h23M85 20h23v23M108 85v23H85M43 108H20V85" stroke-width="8"/>
+    </g>
+    <circle cx="64" cy="55" r="22" fill="#24435A"/>
+    <path fill="#24435A" d="M29 108c5.5-19.5 18.2-30 35-30s29.5 10.5 35 30H29Z"/>
+  </g>
+  <text x="134" y="565" class="wordmark mono">autocrop</text>
+</svg>

--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -99,22 +99,21 @@ main {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 54px;
-  height: 54px;
-  border: 3px solid var(--accent);
-  border-radius: 14px;
-  background:
-    linear-gradient(90deg, transparent 42%, var(--accent) 42%, var(--accent) 58%, transparent 58%),
-    linear-gradient(180deg, transparent 42%, var(--accent) 42%, var(--accent) 58%, transparent 58%),
-    var(--accent-soft);
+  width: 62px;
+  height: 62px;
+  padding: 4px;
+  border-radius: 12px;
 }
 
-.brand-mark span {
-  width: 20px;
-  height: 20px;
-  border: 3px solid var(--accent);
-  border-radius: 50%;
-  background: var(--bg);
+.brand-mark:hover {
+  background: var(--accent-soft);
+  text-decoration: none;
+}
+
+.brand-mark img {
+  display: block;
+  width: 54px;
+  height: 54px;
 }
 
 .eyebrow {


### PR DESCRIPTION
Updates the autocrop mark across the facelifted docs and README.

Changes:
- Adds a reusable filled-silhouette-and-crop-marks logo SVG.
- Updates the favicon to match the filled mark.
- Uses the logo in the docs header.
- Adds Open Graph and Twitter preview metadata.
- Adds an editable SVG social preview that matches the pi-fusion proportions, with the right-side graphic area left empty.
- Uses the SVG preview in the README until a Mac-rendered PNG is available.

Verification:
- Validated SVG XML for the logo, favicon, and social preview.
- Inspected the social preview layout.
- Ran `git diff --check`.
- Ran `just check`.