### PR TITLE
docs: hide grid behind header logo

### DIFF
--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -103,10 +103,13 @@ main {
   height: 62px;
   padding: 4px;
   border-radius: 12px;
+  background: var(--bg);
 }
 
 .brand-mark:hover {
-  background: var(--accent-soft);
+  background:
+    linear-gradient(var(--accent-soft), var(--accent-soft)),
+    var(--bg);
   text-decoration: none;
 }
 


### PR DESCRIPTION
## Summary
- give the docs header logo an opaque page-colored background
- preserve the hover tint by layering it over that solid fill

## Verification
- visually checked a before/after render of the header mark against the docs grid background
- `git diff --check`
- `just check`